### PR TITLE
add option to fail on unused dependencies

### DIFF
--- a/tasks/depcheck.js
+++ b/tasks/depcheck.js
@@ -27,11 +27,7 @@ module.exports = function (grunt) {
     var files = this.filesSrc;
 
     files.forEach(function (f) {
-      depcheck.check(path.resolve(f), {
-        ignoreDirs: options.ignoreDirs,
-        ingoreMatches: options.ingoreMatches,
-        withoutDev: options.withoutDev
-      }, function (unused) {
+      depcheck.check(path.resolve(f), options, function (unused) {
         if (unused.dependencies.length !== 0) {
           fail = options.failOnUnusedDeps;
           grunt.log.warn('Unused Dependencies');

--- a/tasks/depcheck.js
+++ b/tasks/depcheck.js
@@ -16,17 +16,24 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('depcheck', 'Depcheck Grunt plugin', function () {
     var options = this.options({
       'withoutDev': false,
+      'failOnUnusedDeps': false,
       'ignoreDirs': ['.git','.svn','.hg','.idea','node_modules','bower_components'],
       'ingoreMatches': []
     });
 
     var dirsChecked = 0;
     var done = this.async();
+    var fail = false;
     var files = this.filesSrc;
 
     files.forEach(function (f) {
-      depcheck.check(path.resolve(f), options, function (unused) {
+      depcheck.check(path.resolve(f), {
+        ignoreDirs: options.ignoreDirs,
+        ingoreMatches: options.ingoreMatches,
+        withoutDev: options.withoutDev
+      }, function (unused) {
         if (unused.dependencies.length !== 0) {
+          fail = options.failOnUnusedDeps;
           grunt.log.warn('Unused Dependencies');
           unused.dependencies.forEach(function (u) {
             grunt.log.warn('* ' + u);
@@ -34,6 +41,7 @@ module.exports = function (grunt) {
         }
 
         if (unused.devDependencies.length !== 0) {
+          fail = options.failOnUnusedDeps;
           grunt.log.warn();
           grunt.log.warn('Unused devDependencies');
           unused.devDependencies.forEach(function (u) {
@@ -42,7 +50,7 @@ module.exports = function (grunt) {
         }
 
         if (dirsChecked++ === files.length - 1) {
-          done();
+          done(!fail);
         }
       });
     });


### PR DESCRIPTION
This pull request fixes #2 by adding an additional option called `failOnUnusedDeps`. The default value is `false` which means nothing will change for existing users. If you want grunt to fail when an unused dependency is detected set `failOnUnusedDeps` to `true`.

I hope the changes are aligned with the current coding style, because I was not abled to run jshint.
