### PR TITLE
Version 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-depcheck",
   "description": "Depcheck Grunt plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/rumpl/grunt-depcheck",
   "author": {
     "name": "Djordje Lukic",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "depcheck": "^0.4.3"
+    "depcheck": "^0.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "^0.9.2",
+    "grunt": "~0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-nodeunit": "^0.3.3",
-    "grunt": "~0.4.5"
+    "grunt-contrib-jshint": "^0.9.2",
+    "grunt-contrib-nodeunit": "^0.3.3"
   },
   "peerDependencies": {
     "grunt": "~0.4.5"


### PR DESCRIPTION
- Upgrade depcheck version to 0.6.4.
- Declare `grunt-cli` as dev dependency.
- Bump up version to 0.1.1.
