### PR TITLE
update grunt peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-nodeunit": "^0.3.3"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
     "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-nodeunit": "^0.3.3"
   },
-  "peerDependencies": {
-    "grunt": ">=0.4.0"
-  },
   "keywords": [
     "gruntplugin"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-depcheck",
   "description": "Depcheck Grunt plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/rumpl/grunt-depcheck",
   "author": {
     "name": "Djordje Lukic",


### PR DESCRIPTION
This pull request allows grunt-depcheck to be used with versions of grunt larger than 1. I tried to follow the guidelines described in this [blog post](http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released).
