### PR TITLE
Add option to fail on missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ grunt.initConfig({
 Type: `Boolean`  
 Default value: `false`
 
-By default, `depcheck` looks at the devDependencies from the `package.json` file in order to look at unused dependencies. Set this to `true` and 
+By default, `depcheck` looks at the devDependencies from the `package.json` file in order to look at unused dependencies. Set this to `true` and
 it will look only at the `dependencies`.
 
 #### options.ignoreDirs
@@ -56,5 +56,25 @@ Default value: `[]`
 
 Ignore dependencies that match these minimatch patterns. For example `grunt-*`
 
+#### options.failOnUnusedDeps
+Type: `Boolean`  
+Default value: `false`
+
+Set this to `true` to make unused dependencies respond as a failure in Grunt.
+
+#### options.failOnMissingDeps
+Type: `Boolean`  
+Default value: `false`
+
+Set this to `true` to make missing dependencies respond as a failure in Grunt.
+
+#### options.listMissing
+Type: `Boolean`  
+Default value: `false`
+
+By default, only the names of packages that are used but not set in the `package.json` will be included in the Grunt output. Set this to `true`
+and the Grunt output will also list all the files where the missing dependency is being used.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-depcheck",
   "description": "Depcheck Grunt plugin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/rumpl/grunt-depcheck",
   "author": {
     "name": "Djordje Lukic",

--- a/tasks/depcheck.js
+++ b/tasks/depcheck.js
@@ -47,7 +47,7 @@ module.exports = function (grunt) {
           });
         }
 
-        if (unused.missing.length !== 0) {
+        if (unused.missing && Object.keys(unused.missing).length !== 0) {
           fail = options.failOnMissingDeps;
           grunt.log.warn('Missing Dependencies');
           Object.keys(unused.missing).forEach(function (u) {

--- a/tasks/depcheck.js
+++ b/tasks/depcheck.js
@@ -33,8 +33,8 @@ module.exports = function (grunt) {
         if (unused.dependencies.length !== 0) {
           fail = options.failOnUnusedDeps;
           grunt.log.warn('Unused Dependencies');
-          unused.dependencies.forEach(function (u) {
-            grunt.log.warn('* ' + u);
+          unused.dependencies.forEach(function (unusedDependency) {
+            grunt.log.warn('* ' + unusedDependency);
           });
         }
 
@@ -42,19 +42,20 @@ module.exports = function (grunt) {
           fail = options.failOnUnusedDeps;
           grunt.log.warn();
           grunt.log.warn('Unused devDependencies');
-          unused.devDependencies.forEach(function (u) {
-            grunt.log.warn('* ' + u);
+          unused.devDependencies.forEach(function (unusedDevDependency) {
+            grunt.log.warn('* ' + unusedDevDependency);
           });
         }
 
         if (unused.missing && Object.keys(unused.missing).length !== 0) {
           fail = options.failOnMissingDeps;
+          grunt.log.warn();
           grunt.log.warn('Missing Dependencies');
-          Object.keys(unused.missing).forEach(function (u) {
-            var warnString = '* ' + u;
+          Object.keys(unused.missing).forEach(function (missingDependency) {
+            var warnString = '* ' + missingDependency;
             if (options.listMissing) {
-              unused.missing[u].forEach(function (p) {
-                warnString += '\n  in ' + p;
+              unused.missing[missingDependency].forEach(function (missingDependencyFile) {
+                warnString += '\n  in ' + missingDependencyFile;
               });
             }
             grunt.log.warn(warnString);

--- a/tasks/depcheck.js
+++ b/tasks/depcheck.js
@@ -17,6 +17,8 @@ module.exports = function (grunt) {
     var options = this.options({
       'withoutDev': false,
       'failOnUnusedDeps': false,
+      'failOnMissingDeps': false,
+      'listMissing': false,
       'ignoreDirs': ['.git','.svn','.hg','.idea','node_modules','bower_components'],
       'ingoreMatches': []
     });
@@ -42,6 +44,20 @@ module.exports = function (grunt) {
           grunt.log.warn('Unused devDependencies');
           unused.devDependencies.forEach(function (u) {
             grunt.log.warn('* ' + u);
+          });
+        }
+
+        if (unused.missing.length !== 0) {
+          fail = options.failOnMissingDeps;
+          grunt.log.warn('Missing Dependencies');
+          Object.keys(unused.missing).forEach(function (u) {
+            var warnString = '* ' + u;
+            if (options.listMissing) {
+              unused.missing[u].forEach(function (p) {
+                warnString += '\n  in ' + p;
+              });
+            }
+            grunt.log.warn(warnString);
           });
         }
 

--- a/test/depcheck_test.js
+++ b/test/depcheck_test.js
@@ -9,17 +9,19 @@ var fixtures = path.join(__dirname, 'fixtures');
 exports.depcheck = {
   testBad: function (test) {
     depcheck.check(path.join(fixtures, 'bad'), {withoutDev: true}, function (unused) {
-      test.expect(2);
+      test.expect(3);
       test.equal(1, unused.dependencies.length);
       test.equal(0, unused.devDependencies.length);
+      test.equal(1, Object.keys(unused.missing).length);
       test.done();
     });
   },
   testGood: function (test) {
     depcheck.check(path.join(fixtures, 'good'), {withoutDev: true}, function (unused) {
-      test.expect(2);
+      test.expect(3);
       test.equal(0, unused.dependencies.length);
       test.equal(0, unused.devDependencies.length);
+      test.equal(0, Object.keys(unused.missing).length);
       test.done();
     });
   }

--- a/test/fixtures/bad/index.js
+++ b/test/fixtures/bad/index.js
@@ -1,1 +1,2 @@
+var npm = require('npm');
 console.log("I'm bad!");


### PR DESCRIPTION
This pull request adds two additional options called `failOnMissing`, and `listMissing`. 

These two options add the ability to fail the grunt run if there are dependencies that are missing from the `package.json`, but are used in files (`failOnMissing`), and optionally list the files that the dependency is used in (`listMissing`).

The default value for both of these options are false, so nothing will change for existing users.

I added documentation to the two new listings in the README (as well as for `failOnUnusedDeps`), as it was missing), but I'd be happy to modify the wording if you feel it could be better.
