### PR TITLE
Update deps to resolve security vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 language: node_js
 
 node_js:
-  - 0.12
-  - 4
-  - 6
   - 8
   - 10
   - 12
@@ -24,11 +21,11 @@ deploy:
       secure: StcT8gQfJW0nipD0H1fnFrxkl/VijNproaJ/EFg5AJuFtIdsn4OFein03+MYsTg6w1j9V2m8gVhCRD0dvgvCYtnbznoyqEoIf06ws2vHNYlnelPneZDMhsjaxMVnRcOvttUxAYkVJQ8Bn26scnDLwkuiJfNhyBX0hieMMD/IfOI=
     on:
       tags: true
-      node: 6
+      node: 10
   - provider: releases
     skip_cleanup: true
     api_key:
       secure: S9ZDp1V/NAFAPRfJbwiE3++ML5+l9gqQ6NuVLPqQR5qffOzax72mL/sBQUZCVRAw7W8mPCW24FK42KdFgDRCRA9ydCqhoUYAOpS0uQHqhiYFfnoIm6UbKEJ6lMnA3xir15+4JF3iU+Vwag9HMSIw8yOyp1CPBNT9YVYw+mEeIz0=
     on:
       tags: true
-      node: 6
+      node: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ node_js:
   - 0.12
   - 4
   - 6
-  - 7
+  - 8
+  - 10
+  - 12
 
 script:
   - npm run test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-depcheck",
   "description": "Depcheck Grunt plugin",
-  "version": "0.0.1",
+  "version": "0.1.3",
   "homepage": "https://github.com/depcheck/grunt-depcheck",
   "author": {
     "name": "Djordje Lukic",
@@ -31,7 +31,7 @@
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-nodeunit": "^1.0.0",
+    "grunt-contrib-nodeunit": "^2.0.0",
     "patch-version": "^0.1.1"
   },
   "keywords": [
@@ -41,6 +41,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "depcheck": "^0.6.4"
+    "depcheck": "^0.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   ],
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 8.0.0"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Minimal changes to update dependencies so that NPM audit no longer fails. Tests passing (on node 8 & 12 at least) and have also manually tested integration of this new version. 
Would suggest publishing as a patch or minor bump?